### PR TITLE
Fix to enable click events on custom layout

### DIFF
--- a/sample/app/widgets/tiflexigrid/controllers/widget.js
+++ b/sample/app/widgets/tiflexigrid/controllers/widget.js
@@ -1,4 +1,3 @@
-
 exports.createGrid = function(args){
 	var params = args || {};
 	//Ti.API.info('Params es ---> '+ JSON.stringify(params));
@@ -62,7 +61,11 @@ exports.createGrid = function(args){
 		}
 				 
 		frame.add(gridElement);
-		frame.add(overlay);
+		// This condition makes the overlay not be added if it's not gallery layout.
+		// It's used to make the custom view, caputre the click method. If not,
+		// The overlay is on top of it and captures the click.
+		if(layout == 'gallery')
+			frame.add(overlay);
 		
 		$.fgScrollView.add(frame);
 	};


### PR DESCRIPTION
This fix adds a condition to onlyadd the overlay if the layout is gallery. For custom views, overlay should not be there, because it interferes with the custom view when trying to capture the click event.
